### PR TITLE
Was checking for fullchain.pem in root which always exists

### DIFF
--- a/lib/site-ssl
+++ b/lib/site-ssl
@@ -64,7 +64,7 @@ site_ssl_on() {
 	fi
 	
 	# SSL Nginx Conf
-	if [[ -a /etc/letsencrypt/live/$root/fullchain.pem ]]; then
+	if [[ -a /etc/letsencrypt/live/$domain/fullchain.pem ]]; then
 		sudo sed -i '/listen 80/c \	listen 443 ssl http2;' /etc/nginx/sites-available/$domain
 		sudo sed -i '/listen \[::\]:80/c \	listen [::]:443 ssl http2;' /etc/nginx/sites-available/$domain
 		sudo sed -i '/headers-html.conf/a \	include common/headers-https.conf;' /etc/nginx/sites-available/$domain


### PR DESCRIPTION
When adding a domain to a primary site with SSL already enabled, if the new add on domain DNS checks failed, it would still add lines to the add on domain nginx conf for certs that didn't exist after checking for the root certs existence instead of the new domain certs.